### PR TITLE
Fix unnecessary GitHub Actions version specificity and update to modern GitHub Pages deployment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,20 +1,29 @@
-# Builds and publishes the documentation website to gh-pages branch
+# Builds and publishes the documentation website
 name: Build docs
 
 on:
   workflow_dispatch:
+
+concurrency:
+  group: build
+  cancel-in-progress: true
+
+permissions:
+  # Both required by actions/deploy-pages
+  pages: write
+  id-token: write
 
 jobs:
   build:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
         with:
           submodules: true
-    
+
       - name: Setup .NET Core SDK
-        uses: actions/setup-dotnet@v4.0.0
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.x
 
@@ -27,15 +36,9 @@ jobs:
 
       - name: Build Documentation
         run: .\build.ps1
-          
-      - name: Checkout gh-pages
-        uses: actions/checkout@v4.1.1
-        with:
-          ref: gh-pages
-          path: gh-pages
-      - name: Publish to github pages
-        uses: peaceiris/actions-gh-pages@v3.9.3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: _site
-          force_orphan: true
+
+      - name: Upload GitHub Pages Artifact
+        uses: actions/upload-pages-artifact@v3
+
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
**Before merging this PR:** Go to [the GitHub Pages settings](../settings/pages) for this repo and change the build/deployment source to "GitHub Actions".

------------

This PR removes unnecessary version specificity for actions used in GitHub Actions workflows in this repository. This reflects best practices and avoids upcoming issues with `actions/setup-dotnet`, see [this issue](https://github.com/bonsai-rx/bonsai/issues/2091) for details.

While I was at it I migrated the docs workflow to use the modern method for GitHub Pages deployment, and updated other actions as appropriate.